### PR TITLE
Added the eclipse environment variables to the initial parser

### DIFF
--- a/src/cdtconfiguration.cpp
+++ b/src/cdtconfiguration.cpp
@@ -121,4 +121,22 @@ std::ostream& operator<<(std::ostream& os, const configuration_t::build_folder::
 	return os;
 }
 
+//std::ostream& operator<<(std::ostream& os, const configuration_t::environment_variables& l)
+//{
+//	os << "{\n";
+
+//	os << "      flags: " << l.flags << "\n";
+
+//	os << "      libs: ";
+//	std::copy(l.libs.begin(), l.libs.end(), std::ostream_iterator<std::string>(os, ", "));
+//	os << "\n";
+
+//	os << "      lib_paths: ";
+//	std::copy(l.lib_paths.begin(), l.lib_paths.end(), std::ostream_iterator<std::string>(os, ", "));
+//	os << "\n";
+
+//	os << "   }\n";
+//	return os;
+//}
+
 }

--- a/src/cdtconfiguration.h
+++ b/src/cdtconfiguration.h
@@ -77,6 +77,13 @@ struct configuration_t
 	};
 
 	std::vector<excludes> exclude_entries;
+
+	struct environment_variables
+	{
+	  std::string key;
+	  std::string value;
+	};
+	std::vector<environment_variables> env_values;
 };
 
 std::string to_string(configuration_t::Type t);

--- a/src/cdtproject.h
+++ b/src/cdtproject.h
@@ -30,6 +30,7 @@ private:
 
 	TiXmlDocument project_doc;
 	TiXmlDocument cproject_doc;
+	std::vector<std::string> project_vars;
 public:
 	project(const std::string& project_base);
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -254,7 +254,7 @@ void generate(cdt::project& cdtproject, bool write_files)
 	}
 	std::ostream master(buf);
 	
-	master << "cmake_minimum_required (VERSION 2.8)\n";
+	master << "cmake_minimum_required (VERSION 3.5)\n";
 	master << "project (" << project_name << ")\n";
 	master << "\n";
 
@@ -262,6 +262,10 @@ void generate(cdt::project& cdtproject, bool write_files)
 	{
 		auto& c = ac.second;
 		
+		for(cdt::configuration_t::environment_variables env : c.env_values)
+		  {
+		    master << "set ( "  << env.key << " \"" << env.value << "\" )\n";
+		  }
 		switch(c.type)
 		{
 			case cdt::configuration_t::Type::Executable:


### PR DESCRIPTION
What this branche does:
1. Adds data structure component for environmental settings
2. Reads the  `".settings/org.eclipse.cdt.core.prefs"` from an inline definition (yuck)
3. Now sets the CMake version to 3.5

What it does NOT do
1. it does not write the saved environment settings into the CMakeLists settings, since there is a "Merge" path I don't fully understand.
2. it does not translate the internal eclipse settings (such as `WorkspaceDirPath`)