### PR TITLE
Multi config generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cdt2cmake
 
-[![Actions Status](https://badgen.net/github/checks/lukechilds/dockerpi?icon=github&label=Build%20Status)](https://github.com/saterj/cdt2cmake/actions)
+[![Actions Status](https://badgen.net/github/checks/saterj/cdt2cmake?icon=github&label=Build%20Status)](https://github.com/saterj/cdt2cmake/actions)
 
 > Eclipse CDT to CMake converter
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#cdt2cmake
+# cdt2cmake
 
 [![Actions Status](https://badgen.net/github/checks/lukechilds/dockerpi?icon=github&label=Build%20Status)](https://github.com/saterj/cdt2cmake/actions)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-cdt2cmake
-=========
+#cdt2cmake
 
-Eclipse CDT to CMake converter
+[![Actions Status](https://badgen.net/github/checks/lukechilds/dockerpi?icon=github&label=Build%20Status)](https://github.com/saterj/cdt2cmake/actions)
+
+> Eclipse CDT to CMake converter
 
 An ugly, awful, hackish utility written to liberate code from Eclipse CDT.
 

--- a/src/cdt2cmake.cpp
+++ b/src/cdt2cmake.cpp
@@ -98,7 +98,6 @@ void usage(const std::string& program_name)
 	std::cout << "Usage: " << program_name << " [OPTIONS]... /path/to/eclipse-cdt/project/...\n";
 	std::cout << "Converts CDT project file descriptions to CMakeLists.txt files.\n";
 	std::cout << "By default no changes are made to the project source path.\n\n";
-
 	std::cout << "  --generate              Generate the CMakeLists.txt files\n";
 	std::cout << "                          in their appropriate source locations.\n";
 	std::cout << "  --help                  display this help and exit\n";

--- a/src/cdtconfiguration.h
+++ b/src/cdtconfiguration.h
@@ -62,6 +62,7 @@ struct configuration_t
     struct build_file
     {
         std::string file;
+        std::vector<std::string> excluded_config;
         std::string command;
         std::string inputs;
         std::string outputs;

--- a/src/cdtproject.cpp
+++ b/src/cdtproject.cpp
@@ -339,18 +339,32 @@ configuration_t project::configuration(const std::string& cconfiguration_id)
 			throw std::runtime_error("Unknown build node: " + build_instr->ValueStr());
 		}
 	}
+
+	/* Add the project variables to the data structure */
+	conf.env_values.push_back( {"WorkspaceDirPath", "${CMAKE_CURRENT_SOURCE_DIR}"});
+	conf.env_values.push_back( {"ProjName", conf.artifact });
 	for ( std::string& propsLines : project_vars)
 	  {
 	    size_t foundPROJ = propsLines.find(cconfiguration_id);
 	    if (foundPROJ != std::string::npos)
 	      {
+		//TODO: change the CFG to CONFIG or whatever standard Cmake generators do.
 		std::string searchVal = "/value=";
 		size_t foundVAL = propsLines.find(searchVal);
 		if (foundVAL != std::string::npos)
 		  {
 			size_t offset = foundPROJ + cconfiguration_id.length() + 1;
 			configuration_t::environment_variables varies;
-			varies.key = propsLines.substr(offset, foundVAL - offset);
+			std::string keyVal = propsLines.substr(offset, foundVAL - offset);
+			size_t foundFluff = keyVal.find("/") ;
+			if ( foundFluff != std::string::npos)
+			  {
+				varies.key = keyVal.substr(foundFluff + 1, keyVal.length()+1);
+			  }
+			else
+			  {
+				varies.key = keyVal;
+			  }
 			varies.value = propsLines.substr(foundVAL + searchVal.length());
 			conf.env_values.push_back(varies);
 		  }

--- a/src/cdtproject.cpp
+++ b/src/cdtproject.cpp
@@ -345,7 +345,7 @@ configuration_t project::configuration(const std::string& cconfiguration_id)
 	conf.env_values.push_back( {"ProjName", conf.artifact });
 	for ( std::string& propsLines : project_vars)
 	  {
-	    size_t foundPROJ = propsLines.find(cconfiguration_id);
+	    size_t foundPROJ = propsLines.find(cconfiguration_id + "/");
 	    if (foundPROJ != std::string::npos)
 	      {
 		//TODO: change the CFG to CONFIG or whatever standard Cmake generators do.

--- a/src/cdtproject.cpp
+++ b/src/cdtproject.cpp
@@ -267,8 +267,6 @@ configuration_t project::configuration(const std::string& cconfiguration_id)
 				std::string superClass;
 				tool->QueryStringAttribute("superClass", &superClass);
 
-//				fprintf(stderr, "tool: %s\n", superClass.c_str());
-
 				if(superClass.find("cpp.compiler") != std::string::npos)
 					extract_compiler_options(tool, bf.cpp.compiler);
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -16,14 +16,20 @@
 #include <iterator>
 #include "listfile.h"
 
+using std::string;
+using std::stringstream;
+using std::vector;
+using std::pair;
+using std::map;
+
 namespace cmake
 {
 
-bool has_c_sources(const std::map<std::string, std::vector<std::string> >& sources)
+bool has_c_sources(const map<string, vector<string> >& sources)
 {
-	for(const auto& source_folder : sources)
+	for(const pair<string,vector<string>>& source_folder : sources)
 	{
-		for(const auto& source : source_folder.second)
+		for(const string& source : source_folder.second)
 		{
 			if(is_c_source_filename(source))
 				return true;
@@ -32,11 +38,11 @@ bool has_c_sources(const std::map<std::string, std::vector<std::string> >& sourc
 	return false;
 }
 
-bool has_cxx_sources(const std::map<std::string, std::vector<std::string> >& sources)
+bool has_cxx_sources(const map<string, vector<string> >& sources)
 {
-	for(const auto& source_folder : sources)
+	for(const pair<string,vector<string>>& source_folder : sources)
 	{
-		for(const auto& source : source_folder.second)
+		for(const string& source : source_folder.second)
 		{
 			if(is_cxx_source_filename(source))
 				return true;
@@ -47,7 +53,7 @@ bool has_cxx_sources(const std::map<std::string, std::vector<std::string> >& sou
 
 void merge(const cdt::configuration_t::build_folder::compiler_t& source, cdt::configuration_t::build_folder::compiler_t& merged)
 {
-	for(auto inc : source.includes)
+	for(string inc : source.includes)
 	{
 		if(inc.find("\"${workspace_loc:/") == 0)
 		{
@@ -71,13 +77,13 @@ void merge(const cdt::configuration_t::build_folder::compiler_t& source, cdt::co
 			if(inc[inc.size()-1] != '/')
 				inc += '/';
 		}
-	
+
 		if(std::find(merged.includes.begin(), merged.includes.end(), inc) == merged.includes.end())
 		{
 			merged.includes.push_back(inc);
 		}
 	}
-	
+
 	if(source.options != merged.options)
 	{
 		if(merged.options.empty())
@@ -89,12 +95,12 @@ void merge(const cdt::configuration_t::build_folder::compiler_t& source, cdt::co
 
 void merge(const cdt::configuration_t::build_folder::linker_t& source, cdt::configuration_t::build_folder::linker_t& merged)
 {
-	for(auto& lib : source.libs)
+	for(string lib : source.libs)
 	{
 		if(std::find(merged.libs.begin(), merged.libs.end(), lib) == merged.libs.end())
 			merged.libs.push_back(lib);
 	}
-	for(auto lib : source.lib_paths)
+	for(string lib : source.lib_paths)
 	{
 		if(lib.empty())
 			continue;
@@ -116,7 +122,7 @@ void merge(const cdt::configuration_t::build_folder::linker_t& source, cdt::conf
 
 		if(lib.empty())
 			continue;
-		
+
 		if(std::find(merged.lib_paths.begin(), merged.lib_paths.end(), lib) == merged.lib_paths.end())
 			merged.lib_paths.push_back(lib);
 	}
@@ -165,80 +171,108 @@ void merge(const cdt::configuration_t::build_file& source, cdt::configuration_t:
 // one step, take cdt files and write cmakelists.
 void generate(cdt::project& cdtproject, bool write_files)
 {
-	auto project_name = cdtproject.name();
-	auto project_path = cdtproject.path();
+	string project_name = cdtproject.name();
+	string project_path = cdtproject.path();
 
-	std::map<std::string, std::vector<std::string> > sources;
+	map<string, vector<string> > sources;
 	{
-		auto source_files = find_sources(cdtproject.path(), is_source_filename);
-		for(const auto& source : source_files)
-			sources[source.path].push_back(source.name);
+		vector<source_file> source_files = find_sources(cdtproject.path(), is_source_filename);
+		for(source_file& file : source_files)
+			sources[file.path].push_back(file.name);
 	}
 
 	bool lang_c = has_c_sources(sources);
 	bool lang_cxx = has_cxx_sources(sources);
+	map<string, cdt::configuration_t> artifact_configurations;
 
-	std::map<std::string, cdt::configuration_t> artifact_configurations;
-	
-	auto confs = cdtproject.cconfigurations();
-	for(const auto& conf_name : confs)
+	vector<string> confs = cdtproject.cconfigurations();
+	for(string& conf_name : confs)
 	{
-		auto c = cdtproject.configuration(conf_name);
-		cdt::configuration_t& a = artifact_configurations[c.artifact + to_string(c.type)];
-		a.name = c.artifact + to_string(c.type);
-		a.artifact = c.artifact;
-		if(a.prebuild != c.prebuild)
-		{
-			if(a.prebuild.empty())
-				a.prebuild = c.prebuild;
-			else
-				a.prebuild += " / " + c.prebuild;
-		}
-		if(a.postbuild != c.postbuild)
-		{
-			if(a.postbuild.empty())
-				a.postbuild = c.postbuild;
-			else
-				a.postbuild += " / " + c.postbuild;
-		}
-		a.type = c.type;
+		/* create the two configurations to compair */
+		cdt::configuration_t curConfig = cdtproject.configuration(conf_name);
+		cdt::configuration_t& configToAdd = artifact_configurations[curConfig.artifact + to_string(curConfig.type)];
 
-		for(auto& bf : c.build_folders)
+		/* give the candidate config it's name and artifact type */
+//		configToAdd.name = curConfig.artifact + to_string(curConfig.type);
+		configToAdd.name = curConfig.artifact + curConfig.name;
+		configToAdd.artifact = curConfig.artifact;
+
+		/* give the candidate config it's prebuild settings */
+		if(configToAdd.prebuild != curConfig.prebuild)
 		{
-			cdt::configuration_t::build_folder* merged_bf = nullptr;
-			for(auto& abf : a.build_folders)
+			if(configToAdd.prebuild.empty())
+				configToAdd.prebuild = curConfig.prebuild;
+			else
+				configToAdd.prebuild += " / " + curConfig.prebuild;
+		}
+
+		/* give the candidate config it's postbuild settings */
+		if(configToAdd.postbuild != curConfig.postbuild)
+		{
+			if(configToAdd.postbuild.empty())
+				configToAdd.postbuild = curConfig.postbuild;
+			else
+				configToAdd.postbuild += " / " + curConfig.postbuild;
+		}
+		configToAdd.type = curConfig.type;
+
+		/* give the candidate config it's build folders */
+		for(cdt::configuration_t::build_folder& buildFolder : curConfig.build_folders)
+		{
+			cdt::configuration_t::build_folder* merged_folder = nullptr;
+			for(cdt::configuration_t::build_folder& abf : configToAdd.build_folders)
 			{
-				if(abf.path == bf.path)
-					merged_bf = &abf;
+				if(abf.path == buildFolder.path)
+					merged_folder = &abf;
 			}
-			
-			if(!merged_bf)
+
+			/* if the merge folder has not been found */
+			if(!merged_folder)
 			{
 				cdt::configuration_t::build_folder nbf;
-				nbf.path = bf.path;
-				
-				a.build_folders.push_back(nbf);
-				merged_bf = &a.build_folders.back();
+				nbf.path = buildFolder.path;
+
+				configToAdd.build_folders.push_back(nbf);
+				merged_folder = &configToAdd.build_folders.back();
 			}
-			merge(bf, *merged_bf);
+			merge(buildFolder, *merged_folder);
 		}
-		for(auto& bf : c.build_files)
+
+		/* give the candidate config it's build files by looping through this configs files,
+		 * Ultimately, this is a list searching algorithm done in a hard-to-read manner   */
+		for(cdt::configuration_t::build_file& buildFile : curConfig.build_files)
 		{
-			cdt::configuration_t::build_file* merged_bf = nullptr;
-			for(auto& abf : a.build_files)
+			/* create a list of build files */
+			cdt::configuration_t::build_file* merged_file = nullptr;
+
+			/* loop through the totals config and check to see if it matches? */
+			for(cdt::configuration_t::build_file& abf : configToAdd.build_files)
 			{
-				if(abf.file == bf.file)
-					merged_bf = &abf;
+				if(abf.file == buildFile.file)
+					merged_file = &abf;
 			}
-			
-			if(merged_bf)
+
+			/* if a merge file has been found */
+			if(merged_file)
 			{
-				merge(bf, *merged_bf);
+				merge(buildFile, *merged_file);
 			}
 			else
 			{
-				a.build_files.push_back(bf);
+				configToAdd.build_files.push_back(buildFile);
 			}
+		}
+
+		/* give the candidate config it's environment settings */
+		for(cdt::configuration_t::environment_variables& envVar : curConfig.env_values)
+		{
+
+		}
+
+		/* evaluate the candidate config's IGNORE list */
+		for(cdt::configuration_t::excludes& envVar : curConfig.exclude_entries)
+		{
+
 		}
 	}
 
@@ -254,57 +288,57 @@ void generate(cdt::project& cdtproject, bool write_files)
 		buf = std::cout.rdbuf();
 	}
 	std::ostream master(buf);
-	
+
 	master << "cmake_minimum_required (VERSION 3.5)\n\n";
 	master << "project (" << project_name << ")\n\n";
 	master << "\n";
 
-	for(auto& ac : artifact_configurations)
+	for(pair<string, cdt::configuration_t> targetConfig: artifact_configurations)
 	{
-		auto& c = ac.second;
-		
-		for(cdt::configuration_t::environment_variables env : c.env_values)
-		  {
-		    master << "set ( "  << env.key << " \"" << env.value << "\" )\n\n";
-		  }
-		switch(c.type)
+		cdt::configuration_t currentConf = targetConfig.second;
+
+		for(cdt::configuration_t::environment_variables env : currentConf.env_values)
+		{
+		    master << "set ( "  << env.key << " \"" << env.value << "\" )\n";
+		}
+
+		switch(currentConf.type)
 		{
 			case cdt::configuration_t::Type::Executable:
-				master << "add_executable (" << c.artifact;
+				master << "add_executable (" << currentConf.artifact;
 				break;
 			case cdt::configuration_t::Type::StaticLibrary:
-				master << "add_library (" << c.artifact << " STATIC";
+				master << "add_library (" << currentConf.artifact << " STATIC";
 				break;
 			case cdt::configuration_t::Type::SharedLibrary:
-				master << "add_library (" << c.artifact << " SHARED";
+				master << "add_library (" << currentConf.artifact << " SHARED";
 				break;
 		}
-		for(const auto& source_folder : sources)
+		for(const pair<string,vector<string>>& source_folder : sources)
 		{
-			for(const auto& source : source_folder.second)
+			for(const string& source : source_folder.second)
 			{
 				master
 				    << "\n\t"
-				    << (source_folder.first.empty() ? std::string{} : source_folder.first + "/")
+				    << (source_folder.first.empty() ? string{} : source_folder.first + "/")
 				    << source;
 			}
 		}
 		master << ")\n\n";
-		
-		if(!c.prebuild.empty() || !c.postbuild.empty())
+
+		if(!currentConf.prebuild.empty() || !currentConf.postbuild.empty())
 		{
 			master << "\n";
-			master << "# prebuild: " << c.prebuild << "\n";
-			master << "# postbuild: " << c.postbuild << "\n";
+			master << "# prebuild: " << currentConf.prebuild << "\n";
+			master << "# postbuild: " << currentConf.postbuild << "\n";
 			master << "\n";
 		}
-		
-		for(auto& bf : c.build_folders)
+
+		for(cdt::configuration_t::build_folder& bf : currentConf.build_folders)
 		{
 			if(bf.path.empty())
 			{
 				// master
-				
 				{
 					if(!bf.cpp.compiler.includes.empty() || !bf.c.compiler.includes.empty())
 					{
@@ -312,73 +346,73 @@ void generate(cdt::project& cdtproject, bool write_files)
 						master << "INCLUDE_DIRECTORIES(";
 						if(lang_cxx)
 						{
-							for(auto& inc : bf.cpp.compiler.includes)
+							for(string& inc : bf.cpp.compiler.includes)
 								master << (bf.cpp.compiler.includes.size() > 3 ? "\n\t" : " ") << '"' << inc << '"';
 						}
 						if(lang_c)
 						{
-							for(auto& inc : bf.c.compiler.includes)
+							for(string& inc : bf.c.compiler.includes)
 								master << (bf.c.compiler.includes.size() > 3 ? "\n\t" : " ") << '"' << inc << '"';
 						}
 						master << ")\n\n";
 					}
-					
-					std::vector<std::string> options;
+
+					vector<string> options;
 					if(lang_cxx)
 					{
-						std::stringstream ss(bf.cpp.compiler.options);
-						std::vector<std::string> opts(std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{});
-						for(auto& o : opts)
+						stringstream ss(bf.cpp.compiler.options);
+						vector<string> opts(std::istream_iterator<string>{ss}, std::istream_iterator<string>{});
+						for(string& opt : opts)
 						{
-							if(std::find(begin(options), end(options), o) == end(options))
-								options.push_back(o);
+							if(std::find(begin(options), end(options), opt) == end(options))
+								options.push_back(opt);
 						}
 					}
 					if(lang_c)
 					{
-						std::stringstream ss(bf.c.compiler.options);
-						std::vector<std::string> opts(std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{});
-						for(auto& o : opts)
+						stringstream ss(bf.c.compiler.options);
+						vector<string> opts(std::istream_iterator<string>{ss}, std::istream_iterator<string>{});
+						for(string& opt : opts)
 						{
-							if(std::find(begin(options), end(options), o) == end(options))
-								options.push_back(o);
+							if(std::find(begin(options), end(options), opt) == end(options))
+								options.push_back(opt);
 						}
 					}
-					
+
 					if(!options.empty())
 					{
-						master << "set_target_properties(" << c.artifact << " PROPERTIES COMPILE_FLAGS \"";
-						for(auto& o : options)
-							master << o << ' ';
+						master << "set_target_properties(" << currentConf.artifact << " PROPERTIES COMPILE_FLAGS \"";
+						for(string& option : options)
+							master << option << ' ';
 						master << "\")\n\n";
 					}
 				}
-				
+
 				if(lang_cxx)
 				{
 					// use c++ linker settings.
 					if(!bf.cpp.linker.flags.empty())
 					{
-						std::vector<std::string> flags;
-						
-						std::stringstream ss(bf.cpp.linker.flags);
-						std::vector<std::string> opts(std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{});
-						for(auto& o : opts)
+						vector<string> flags;
+						stringstream ss(bf.cpp.linker.flags);
+						vector<string> opts(std::istream_iterator<string>{ss}, std::istream_iterator<string>{});
+
+						for(string& opt : opts)
 						{
-							if(std::find(begin(flags), end(flags), o) == end(flags))
-								flags.push_back(o);
+							if(std::find(begin(flags), end(flags), opt) == end(flags))
+								flags.push_back(opt);
 						}
-						
-						master << "set_target_properties(" << c.artifact << " PROPERTIES LINK_FLAGS \"";
-						for(auto& o : flags)
-							master << o << ' ';
+
+						master << "set_target_properties(" << currentConf.artifact << " PROPERTIES LINK_FLAGS \"";
+						for(string& flag : flags)
+							master << flag << ' ';
 						master << "\")\n\n";
 					}
-				
+
 					if(!bf.cpp.linker.lib_paths.empty())
 					{
 						master << "link_directories (";
-						for(auto& path : bf.cpp.linker.lib_paths)
+						for(string& path : bf.cpp.linker.lib_paths)
 							master
 							    << (bf.cpp.linker.lib_paths.size() > 3 ? "\n\t" : " ")
 							    << path;
@@ -387,8 +421,8 @@ void generate(cdt::project& cdtproject, bool write_files)
 
 					if(!bf.cpp.linker.libs.empty())
 					{
-						master << "target_link_libraries (" << c.artifact;
-						for(auto& lib : bf.cpp.linker.libs)
+						master << "target_link_libraries (" << currentConf.artifact;
+						for(string& lib : bf.cpp.linker.libs)
 							master << (bf.cpp.linker.libs.size() > 3 ? "\n\t" : " ") << lib;
 						master << ")\n\n";
 					}
@@ -397,34 +431,34 @@ void generate(cdt::project& cdtproject, bool write_files)
 				{
 					if(!bf.c.linker.flags.empty())
 					{
-						std::vector<std::string> flags;
-						
-						std::stringstream ss(bf.c.linker.flags);
-						std::vector<std::string> opts(std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{});
-						for(auto& o : opts)
+						vector<string> flags;
+						stringstream ss(bf.c.linker.flags);
+						vector<string> opts(std::istream_iterator<string>{ss}, std::istream_iterator<string>{});
+
+						for(string& opt : opts)
 						{
-							if(std::find(begin(flags), end(flags), o) == end(flags))
-								flags.push_back(o);
+							if(std::find(begin(flags), end(flags), opt) == end(flags))
+								flags.push_back(opt);
 						}
-						
-						master << "set_target_properties(" << c.artifact << " PROPERTIES LINK_FLAGS \"";
-						for(auto& o : flags)
-							master << o << ' ';
+
+						master << "set_target_properties(" << currentConf.artifact << " PROPERTIES LINK_FLAGS \"";
+						for(string& opt : flags)
+							master << opt << ' ';
 						master << "\")\n\n";
 					}
-				
+
 					if(!bf.c.linker.lib_paths.empty())
 					{
 						master << "link_directories (";
-						for(auto& path : bf.c.linker.lib_paths)
+						for(string& path : bf.c.linker.lib_paths)
 							master << (bf.c.linker.lib_paths.size() > 3 ? "\n\t" : " ") << path;
 						master << ")\n\n";
 					}
 
 					if(!bf.c.linker.libs.empty())
 					{
-						master << "target_link_libraries (" << c.artifact;
-						for(auto& lib : bf.c.linker.libs)
+						master << "target_link_libraries (" << currentConf.artifact;
+						for(string& lib : bf.c.linker.libs)
 							master << (bf.c.linker.libs.size() > 3 ? "\n\t" : " ") << lib;
 						master << ")\n\n";
 					}
@@ -437,14 +471,14 @@ void generate(cdt::project& cdtproject, bool write_files)
 				// subdirectory
 			}
 		}
-		
-		for(auto& bf : c.build_files)
+
+		for(cdt::configuration_t::build_file& bf : currentConf.build_files)
 		{
 			// TODO
 			master << "# TODO " << bf.file << '\n';
 		}
 	}
-	
+
 	master << '\n';
 }
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -378,11 +378,12 @@ void generate(cdt::project& cdtproject, bool write_files)
 			{
 				string singleNOTbeginner = "$<$<NOT:$<CONFIG:";
 				filepath = singleNOTbeginner + curConfig.name + ">>:" + filepath + ">";
-				size_t onlyHasOne = filepath.find(singleNOTbeginner);
-				if(onlyHasOne != string::npos)
-				{
-					printf("Hi");
-				}
+//				size_t onlyHasOne = filepath.find(singleNOTbeginner);
+//				if(onlyHasOne != string::npos)
+//				{
+//				    filepath = filepath.substr(0,isInThisOne-1)
+//					filePath = "$<$<NOT:$<OR:$<CONFIG:" + filepath.substr(singleNOTbeginner.size());
+//				}
 			}
 		    }
 		}

--- a/src/project.h
+++ b/src/project.h
@@ -19,9 +19,7 @@ struct project;
 
 namespace cmake
 {
-
 void generate(cdt::project& cdtproject, bool write_files);
-
 }
 
 #endif /* PROJECT_H_ */

--- a/src/sourcediscovery.cpp
+++ b/src/sourcediscovery.cpp
@@ -9,61 +9,63 @@
 #include <algorithm>
 #include <dirent.h>
 
-bool is_source_filename(const std::string& filename)
+using std::string;
+
+bool is_source_filename(const string& filename)
 {
 	static const auto c_types = {".c", ".C", "c++", ".cc", ".cpp", ".cxx"};
 
-	std::string::size_type pos = filename.rfind('.');
-	if(pos == std::string::npos)
+	string::size_type pos = filename.rfind('.');
+	if(pos == string::npos)
 		return false;
 
 	auto file_type = filename.substr(pos);
 	return std::find(begin(c_types), end(c_types), file_type) != end(c_types);
 }
 
-bool is_c_source_filename(const std::string& filename)
+bool is_c_source_filename(const string& filename)
 {
 	static const auto c_types = {".c"};
 
-	std::string::size_type pos = filename.rfind('.');
-	if(pos == std::string::npos)
+	string::size_type pos = filename.rfind('.');
+	if(pos == string::npos)
 		return false;
 
 	auto file_type = filename.substr(pos);
 	return std::find(begin(c_types), end(c_types), file_type) != end(c_types);
 }
 
-bool is_cxx_source_filename(const std::string& filename)
+bool is_cxx_source_filename(const string& filename)
 {
 	static const auto c_types = {".C", "c++", ".cc", ".cpp", ".cxx"};
 
-	std::string::size_type pos = filename.rfind('.');
-	if(pos == std::string::npos)
+	string::size_type pos = filename.rfind('.');
+	if(pos == string::npos)
 		return false;
 
 	auto file_type = filename.substr(pos);
 	return std::find(begin(c_types), end(c_types), file_type) != end(c_types);
 }
 
-void find_sources(const std::string& base_path, const std::string& path, const std::function<bool(std::string)>& predicate, std::vector<source_file>& sources)
+void find_sources(const string& base_path, const string& path, const std::function<bool(string)>& predicate, std::vector<source_file>& sources)
 {
-	auto abs_path = base_path;
+	string abs_path = base_path;
 
 	if(!path.empty())
 		abs_path += "/" + path;
 
-	auto d = opendir(abs_path.c_str());
-	if(d)
+	DIR* directory = opendir(abs_path.c_str());
+	if(directory)
 	{
-		while (auto dir = readdir(d))
+		while (dirent* dir = readdir(directory))
 		{
-			std::string name = dir->d_name;
+			string name = dir->d_name;
 			if(dir->d_type == DT_DIR)
 			{
 				if(name == "." || name == ".." || name == "CMakeFiles")
 					continue;
 
-				auto rel_path = name;
+				string rel_path = name;
 				if(!path.empty())
 					rel_path = path + "/" + name;
 
@@ -73,7 +75,7 @@ void find_sources(const std::string& base_path, const std::string& path, const s
 			{
 				if(predicate(name))
 				{
-					auto rel_source = name;
+					string rel_source = name;
 					if(!path.empty())
 						rel_source = path + "/" + name;
 
@@ -81,13 +83,14 @@ void find_sources(const std::string& base_path, const std::string& path, const s
 				}
 			}
 		}
-		closedir(d);
+		closedir(directory);
 	}
 }
 
-std::vector<source_file> find_sources(const std::string& base_path, const std::function<bool(std::string)>& predicate)
+using std::vector;
+vector<source_file> find_sources(const string& base_path, const std::function<bool(string)>& predicate)
 {
-	std::vector<source_file> sources;
+	vector<source_file> sources;
 	find_sources(base_path, {}, predicate, sources);
 
 	return std::move(sources);


### PR DESCRIPTION
Adding the full evaluation of eclipse environment variables. They now get set via `SET()` and are qualified with generator expressions, thus requiring the use of setting the `CMAKE_BUILD_TYPE` variable.

Example
```bash
cmake -DCMAKE_BUILD_TYPE=Release . 
```